### PR TITLE
Morphs for Pre-Lightwave 2015 did not have negative z values found in…

### DIFF
--- a/Lightwave/Lightwave_Pre_2015/LW_CopyToExternal.py
+++ b/Lightwave/Lightwave_Pre_2015/LW_CopyToExternal.py
@@ -156,7 +156,7 @@ class OD_LWCopyToExternal(lwsdk.ICommandSequence):
         for point in points:
           if (mesh_edit_op.pointVGet(mesh_edit_op.state,point)[1]) != None:
             ms = mesh_edit_op.pointVGet(mesh_edit_op.state,point)[1]
-            f.write(str(ms[0]) + " " + str(ms[1]) + " " + str(ms[2]) + "\n")
+            f.write(str(ms[0]) + " " + str(ms[1]) + " " + str(ms[2]*-1) + "\n")
           else:
             f.write("None\n")
     except:

--- a/Lightwave/Lightwave_Pre_2015/LW_PasteFromExternal.py
+++ b/Lightwave/Lightwave_Pre_2015/LW_PasteFromExternal.py
@@ -117,13 +117,13 @@ class OD_LWPasteFromExternal(lwsdk.ICommandSequence):
           if lines[weightMap[1]+1+count].strip() != "None":
             mesh_edit_op.pntVMap(mesh_edit_op.state, point, lwsdk.LWVMAP_WGHT, weightMap[0], [float(lines[weightMap[1]+1+count].strip())])
           count += 1
-      #Set Mprph Map Values
+      #Set Morph Map Values
       for morphMap in morphMaps:
         mesh_edit_op.vMapSelect(mesh_edit_op.state, morphMap[0], lwsdk.LWVMAP_MORF, 3)
         count = 0
         for point in points:
           if lines[morphMap[1]+1+count].strip() != "None":
-            mesh_edit_op.pntVMap(mesh_edit_op.state, point, lwsdk.LWVMAP_MORF, morphMap[0], [float(lines[morphMap[1]+1+count].split(" ")[0]), float(lines[morphMap[1]+1+count].split(" ")[1]), float(lines[morphMap[1]+1+count].split(" ")[2])])
+            mesh_edit_op.pntVMap(mesh_edit_op.state, point, lwsdk.LWVMAP_MORF, morphMap[0], [float(lines[morphMap[1]+1+count].split(" ")[0]), float(lines[morphMap[1]+1+count].split(" ")[1]), float(lines[morphMap[1]+1+count].split(" ")[2])*-1])
           count += 1
       #Set UV Map Values
       for uvMap in uvMaps:


### PR DESCRIPTION
Pre-2015 Lightwave morphs in the z direction have the wrong sign. Changed to match code for the Lightwave 2015 version.